### PR TITLE
Clone defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,8 @@ function aliases(aliases) {
 }
 
 function defaults(defaults, aliases) {
+  var out = {}
+
   if (undefined !== defaults) {
     for (var key in aliases) {
       var value = defaults[key]
@@ -91,24 +93,23 @@ function defaults(defaults, aliases) {
 
       if (undefined !== value) {
         for (var i = 0, len = alias.length; i < len; i++) {
-          defaults[alias[i]] = value
+          out[alias[i]] = value
         }
       } else {
         for (var i = 0, len = alias.length; i < len; i++) {
           if (undefined !== (value = defaults[alias[i]])) {
-            defaults[key] = value
+            out[key] = value
 
-            for (var j = 0; j < len; j++) {
-              if (i !== j) {
-                defaults[alias[j]] = value
-              }
+            for (i = 0; i < len; i++) {
+              out[alias[i]] = value
             }
           }
         }
       }
     }
   }
-  return defaults
+
+  return out
 }
 
 function set(key, value, out, aliases, unknown) {

--- a/test/default.js
+++ b/test/default.js
@@ -2,8 +2,13 @@ const test = require("tape")
 const getopts = require("../")
 
 test("opts.default", t => {
-  t.plan(1)
+  t.plan(3)
 
+  const defaults = {
+    c: true,
+    D: true,
+    e: false
+  }
   t.deepEqual(
     getopts(["-abC"], {
       alias: {
@@ -13,11 +18,7 @@ test("opts.default", t => {
         d: "D",
         E: ["e", "eek", "eh"]
       },
-      default: {
-        c: true,
-        D: true,
-        e: false
-      }
+      default: defaults
     }),
     {
       _: [],
@@ -33,6 +34,33 @@ test("opts.default", t => {
       E: false,
       eek: false,
       eh: false
+    }
+  )
+
+  t.deepEqual(
+    defaults,
+    {
+      c: true,
+      D: true,
+      e: false
+    }
+  )
+
+  t.deepEqual(
+    getopts([], {
+      alias: {
+        a: ["A", "B"],
+      },
+      default: {
+        A: true,
+        B: false,
+      }
+    }),
+    {
+      _: [],
+      a: true,
+      A: true,
+      B: true,
     }
   )
 })


### PR DESCRIPTION
Avoids mutating an object that's not owned, and stops after finding the
first alias with a default.