### PR TITLE
Use String#substring

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,13 +23,13 @@ function parse(args, aliases, defaults, unknown, out) {
       if ("-" === arg[1]) {
         var end = arg.indexOf("=")
         if (0 <= end) {
-          set(arg.slice(2, end), arg.slice(end + 1), out, aliases, unknown)
+          set(arg.substring(2, end), arg.substring(end + 1), out, aliases, unknown)
         } else {
           if ("n" === arg[2] && "o" === arg[3] && "-" === arg[4]) {
-            set(arg.slice(5), false, out, aliases, unknown)
+            set(arg.substring(5), false, out, aliases, unknown)
           } else {
             set(
-              arg.slice(2),
+              arg.substring(2),
               (j = i + 1) === len || "-" === args[j][0] || args[(i = j)],
               out,
               aliases,
@@ -38,10 +38,10 @@ function parse(args, aliases, defaults, unknown, out) {
           }
         }
       } else {
-        var end = arg.slice(2).search(SHORTSPLIT) + 2
+        var end = arg.substring(2).search(SHORTSPLIT) + 2
         var value = end === arg.length
           ? (j = i + 1) === len || "-" === args[j][0] || args[(i = j)]
-          : arg.slice(end)
+          : arg.substring(end)
 
         for (j = 1; j < end; ) {
           set(arg[j], ++j !== end || value, out, aliases, unknown)


### PR DESCRIPTION
It's marginally faster, since it does less checks internally.
Both `#slice` and `#substr` allow negative numbers, which slows them
down in comparison.

```
getopts × 1,101,905 ops/sec
pr × 1,212,038 ops/sec

getopts × 1,121,022 ops/sec
pr × 1,224,245 ops/sec

getopts × 1,215,753 ops/sec
pr × 1,218,235 ops/sec

getopts × 1,124,221 ops/sec
pr × 1,218,805 ops/sec

getopts × 1,055,974 ops/sec
pr × 1,192,571 ops/sec