### PR TITLE
Optimize defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,11 @@ const SHORTSPLIT = /$|[!-@\[-`{-~]/
 
 module.exports = function(args, opts) {
   opts = opts || {}
+  var alias = aliases(opts.alias)
   return parse(
     args,
-    aliases(opts.alias),
-    defaults(opts.default, opts.alias),
+    alias,
+    defaults(opts.default, alias),
     opts.unknown,
     { _: [] }
   )
@@ -86,24 +87,16 @@ function aliases(aliases) {
 function defaults(defaults, aliases) {
   var out = {}
 
-  if (undefined !== defaults) {
-    for (var key in aliases) {
-      var value = defaults[key]
-      var alias = toArray(aliases[key])
+  for (var key in defaults) {
+    var value = defaults[key];
+    var alias = aliases[key];
 
-      if (undefined !== value) {
+    if (undefined === out[key]) {
+      out[key] = value;
+
+      if (undefined !== alias) {
         for (var i = 0, len = alias.length; i < len; i++) {
           out[alias[i]] = value
-        }
-      } else {
-        for (var i = 0, len = alias.length; i < len; i++) {
-          if (undefined !== (value = defaults[alias[i]])) {
-            out[key] = value
-
-            for (i = 0; i < len; i++) {
-              out[alias[i]] = value
-            }
-          }
         }
       }
     }

--- a/test/default.js
+++ b/test/default.js
@@ -7,7 +7,8 @@ test("opts.default", t => {
   const defaults = {
     c: true,
     D: true,
-    e: false
+    e: false,
+    f: false
   }
   t.deepEqual(
     getopts(["-abC"], {
@@ -33,7 +34,8 @@ test("opts.default", t => {
       e: false,
       E: false,
       eek: false,
-      eh: false
+      eh: false,
+      f: false
     }
   )
 
@@ -42,7 +44,8 @@ test("opts.default", t => {
     {
       c: true,
       D: true,
-      e: false
+      e: false,
+      f: false
     }
   )
 
@@ -53,14 +56,14 @@ test("opts.default", t => {
       },
       default: {
         A: true,
-        B: false,
+        B: false
       }
     }),
     {
       _: [],
       a: true,
       A: true,
-      B: true,
+      B: true
     }
   )
 })


### PR DESCRIPTION
Now that defaults clones, we can loop over the user provided options
directly. This should speed up cases where there are less defaults than
there are aliases.