### PR TITLE
Handle boolean flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ getopts(["-b"], {
 }) //=> { _:[], b:true, B:true, boost:true }
 ```
 
+#### option.boolean
+
+An array of options that should be parsed as booleans.
+
+```js
+getopts(["-f", "bar"], {
+  boolean: ["f"]
+}) //=> { _:["bar"], f:true }
+```
+
 #### options.default
 
 An object of default values for missing options.

--- a/test/boolean.js
+++ b/test/boolean.js
@@ -1,0 +1,39 @@
+const test = require("tape")
+const getopts = require("../")
+
+test("opts.boolean", t => {
+  t.plan(2)
+
+  const booleans = ['c', 'D', 'e', 'boolean']
+  t.deepEqual(
+    getopts(["-abC", "operand", "--boolean", "operand"], {
+      alias: {
+        A: "a",
+        b: "B",
+        c: "C",
+      },
+      boolean: booleans
+    }),
+    {
+      _: ["operand", "operand"],
+      a: true,
+      A: true,
+      b: true,
+      B: true,
+      c: true,
+      C: true,
+      boolean: true
+    }
+  )
+
+  t.deepEqual(
+    getopts(['-a1', '--boolean=2'], {
+      boolean: ['a', 'boolean']
+    }),
+    {
+      _: [],
+      a: '1',
+      boolean: '2'
+    }
+  )
+})

--- a/test/unknown.js
+++ b/test/unknown.js
@@ -2,7 +2,7 @@ const test = require("tape")
 const getopts = require("../")
 
 test("opts.unknown", t => {
-  t.plan(3)
+  t.plan(4)
 
   t.deepEqual(
     getopts(["-abC"], {
@@ -29,6 +29,17 @@ test("opts.unknown", t => {
     {
       _: [],
       a: true,
+    }
+  )
+
+  t.deepEqual(
+    getopts(["-abC"], {
+      boolean: ['a'],
+      unknown: option => false
+    }),
+    {
+      _: [],
+      a: true
     }
   )
 


### PR DESCRIPTION
Not all options require an argument, but we treated everything (minus leading shorthands) as needing one. The easiest way to demonstrate is with an example:

```bash
$ git push -f origin master
```

Here, `-f` doesn't take an argument, so returning `{ f: "origin" }` is definitely wrong.

I'm solving this by passing a `boolean` array into the parser. This is so we can support both the current (by default) and the boolean syntax:

```bash
$ curl -X POST ... { x: "POST" }
$ git push -f origin master ... { _: ['push', 'origin', 'master'], f: true }
```