### PR TITLE
Export TypeScript interfaces

### DIFF
--- a/getopts.d.ts
+++ b/getopts.d.ts
@@ -1,20 +1,22 @@
-interface ParsedOptions {
-  _: string[]
-  [key: string]: any
-}
-
-interface Options {
-  alias?: { [key: string]: string | string[] }
-  boolean?: string[]
-  default?: { [key: string]: any }
-  unknown?: (optionName: string) => boolean
-}
-
 /**
  * @param argv Arguments to parse.
  * @param options Options.
  * @returns An object with parsed options.
  */
-declare function getopts(argv: string[], options?: Options): ParsedOptions
+declare function getopts(argv: string[], options?: getopts.Options): getopts.ParsedOptions
 
 export = getopts
+
+declare namespace getopts {
+  export interface ParsedOptions {
+    _: string[]
+    [key: string]: any
+  }
+  
+  export interface Options {
+    alias?: { [key: string]: string | string[] }
+    boolean?: string[]
+    default?: { [key: string]: any }
+    unknown?: (optionName: string) => boolean
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "release": "npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push origin master && git push --tags && npm publish"
   },
   "devDependencies": {
+    "@types/node": "^10.12.0",
     "nyc": "^12.0.2",
     "testmatrix": "^0.1.2",
     "typescript": "^3.0.1"

--- a/test/ts/index.ts
+++ b/test/ts/index.ts
@@ -1,4 +1,4 @@
-import getopts from "getopts"
+import getopts, {ParsedOptions, Options} from "getopts"
 
 console.log(
   getopts(["-s"], {
@@ -11,3 +11,19 @@ console.log(
     }
   })
 )
+
+function wrapGetopts(input: string, options: Options): ParsedOptions {
+  return getopts(input.split(" "), options)
+}
+
+const options: Options = {
+  alias: {
+    e: "export"
+  },
+  boolean: ["export"],
+  default: {
+    export: false
+  }
+}
+
+wrapGetopts("-e", options)

--- a/test/ts/index.ts
+++ b/test/ts/index.ts
@@ -12,18 +12,18 @@ console.log(
   })
 )
 
-function wrapGetopts(input: string, options: Options): ParsedOptions {
-  return getopts(input.split(" "), options)
-}
-
 const options: Options = {
   alias: {
-    e: "export"
+    s: "super"
   },
-  boolean: ["export"],
+  boolean: ["super"],
   default: {
-    export: false
+    super: true
   }
 }
 
-wrapGetopts("-e", options)
+const parsedOptions: ParsedOptions = getopts(["-s"], options)
+
+if (!parsedOptions.super) {
+  process.exit(1)
+}


### PR DESCRIPTION
This pull request exports the interfaces used in `getopts.d.ts` so that TypeScript users can easily use them.

I'm making this because I had an issue where TypeScript was throwing `TS4058` since I was returning the output from a getopts call directly in a function, and it wasn't able to import the interface for the generated definitions, meaning I had to had to copy the interface and then explicitly define it as a return value, as seen [here](https://github.com/erisaaa/commands/blob/master/src/parseArgs.ts#L7-L10) and [here](https://github.com/erisaaa/commands/blob/master/src/parseArgs.ts#L42-L44)