### PR TITLE
Update benchmark

### DIFF
--- a/bench/package.json
+++ b/bench/package.json
@@ -1,9 +1,11 @@
 {
   "private": true,
   "dependencies": {
-    "benchmark": "^2.1.4",
-    "minimist": "^1.2.0",
-    "mri": "^1.1.4",
-    "yargs-parser": "13.1.1"
+    "benchmark": "*",
+    "getopts": "*",
+    "minimist": "*",
+    "mri": "*",
+    "nopt": "*",
+    "yargs-parser": "*"
   }
 }


### PR DESCRIPTION
- Change to use the latest version of each library
- Add library `nopt`
- Add library `getopts` in order to compare the current implementation to the prior version
- Change to parse more argument types